### PR TITLE
Adicionando quebra de linha nas informações dos desafios

### DIFF
--- a/2019-Novembro-WebSocket/README.md
+++ b/2019-Novembro-WebSocket/README.md
@@ -1,10 +1,10 @@
 # Desafio333 - Novembro 2019 - WebSocket
 
-**Tecnologia:** WebSocket
-**Áreas:** Back-End, Front-End e Criatividade
-**Data de Lançamento:** 02/11/2019
-**Data Limite para Participação:** 05/12/2019
-**Data de Anúncio dos Vencedores:** 19/12/2019
+**Tecnologia:** WebSocket <br>
+**Áreas:** Back-End, Front-End e Criatividade <br>
+**Data de Lançamento:** 02/11/2019 <br>
+**Data Limite para Participação:** 05/12/2019 <br>
+**Data de Anúncio dos Vencedores:** 19/12/2019 <br>
 **Vencedores:**
 
 O desafio do mês de Novembro é focado em WebSockets e será possível usar **qualquer linguagem de programação**, juntamente com **qualquer framework**.

--- a/2019-Outubro-Url-Preview/README.md
+++ b/2019-Outubro-Url-Preview/README.md
@@ -1,10 +1,10 @@
 # Desafio333 - Outubro 2019 - API URL Preview
 
-**Tecnologia:** Livre
-**Áreas:** Back-End + Opcional Front-End
-**Data de Lançamento:** 10/10/2019
-**Data Limite para Participação:** 26/10/2019
-**Data de Anúncio dos Vencedores:** 14/11/2019
+**Tecnologia:** Livre <br>
+**Áreas:** Back-End + Opcional Front-End <br>
+**Data de Lançamento:** 10/10/2019 <br>
+**Data Limite para Participação:** 26/10/2019 <br>
+**Data de Anúncio dos Vencedores:** 14/11/2019 <br>
 **Vencedores:**
 
 O desafio do mês de Outubro é focado em Back-End e será possível usar **qualquer linguagem de programação**.


### PR DESCRIPTION
Alterado o header dos desafios de outubro e novembro.

### Atualmente: 
<kbd>![image](https://user-images.githubusercontent.com/3982052/68093509-f618e980-fe74-11e9-9aca-7d107107a62a.png)</kbd>

### Alteração:
<kbd>![image](https://user-images.githubusercontent.com/3982052/68093505-e9949100-fe74-11e9-9e3b-d1763ea7083b.png)</kbd>